### PR TITLE
Update grunt-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-uglify": "^0.9.1",
-    "grunt-eslint": "^13.0.0"
+    "grunt-eslint": "^17.1.0"
   }
 }


### PR DESCRIPTION
Fixes red "devDependencies out of date" badge from david-dm.